### PR TITLE
Add staticize method recipe

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,3 @@
-rootProject.name = "rewrite-recipe-starter"
+rootProject.name = "rewrite-recipe-starter-kunli-exercise"
 
 enableFeaturePreview("VERSION_ORDERING_V2")

--- a/src/main/java/com/yourorg/StaticizeNonOverridableMethods.java
+++ b/src/main/java/com/yourorg/StaticizeNonOverridableMethods.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yourorg;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.Cursor;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.Tree;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.cleanup.ModifierOrder;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.Space;
+
+@Value
+@EqualsAndHashCode(callSuper = true)
+public class StaticizeNonOverridableMethods extends Recipe {
+
+  @Override
+  public String getDisplayName() {
+    return "Add `static` to private or final method that don't access instance data";
+  }
+
+  @Override
+  public String getDescription() {
+    return "Add the `static` modifier keyword to non-overridable methods (private or final) that don’t access instance data.";
+  }
+
+  @Override
+  public JavaIsoVisitor<ExecutionContext> getVisitor() {
+    return new JavaIsoVisitor<ExecutionContext>() {
+
+      private Set<J.VariableDeclarations.NamedVariable> instanceVariables = new HashSet<>();
+      private Set<J.MethodDeclaration> instanceMethods = new HashSet<>();
+
+      @Override
+      public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
+        System.out.println("[Kun] visitClassDeclaration : " + classDecl);
+
+        // skip static class
+        if (classDecl.hasModifier(J.Modifier.Type.Static)) {
+          return classDecl;
+        }
+
+        Set<J.VariableDeclarations.NamedVariable> vs = CollectInstanceVariables.collect(classDecl);
+        instanceVariables.addAll(vs);
+
+        Set<J.MethodDeclaration> ms = CollectInstanceMethods.collect(classDecl);
+        instanceMethods.addAll(ms);
+
+        return super.visitClassDeclaration(classDecl, ctx);
+      }
+
+      @Override
+      public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
+        System.out.println("[Kun] visitMethodDeclaration : " + method.toString());
+
+        J.MethodDeclaration m = super.visitMethodDeclaration(method, ctx);
+
+        // if it already has `static` modifier, it doesn't need to add again.
+        if (m.hasModifier(J.Modifier.Type.Static)) {
+          return m;
+        }
+
+        // if it's an overridable methods (neither `private` nor `final`), we don't want to add `static`.
+        if (!m.hasModifier(J.Modifier.Type.Private) && !m.hasModifier(J.Modifier.Type.Final)) {
+          return m;
+        }
+
+        boolean hasInstanceDataAccess = FindInstanceDataAccess.find(method,
+            instanceMethods,
+            instanceVariables
+        ).get();
+
+        return hasInstanceDataAccess ? m : addStatic(m);
+      }
+    };
+  }
+
+  private static J.MethodDeclaration addStatic(J.MethodDeclaration m) {
+    // it expects the input method is non-overridable, so it should has at least one modifier(`private` or `final`)
+    if (m.getModifiers().isEmpty()) {
+      return m;
+    }
+
+    Space singleSpace = Space.build(" ", Collections.emptyList());
+    J.Modifier staticMod = m.getModifiers().stream()
+        .findFirst()
+        .get()
+        .withId(Tree.randomId())
+        .withPrefix(singleSpace)
+        .withType(J.Modifier.Type.Static);
+    List<J.Modifier> modifiers = new ArrayList<>(m.getModifiers());
+    modifiers.add(staticMod);
+    return m.withModifiers(ModifierOrder.sortModifiers(modifiers));
+  }
+
+  private boolean isField(Cursor cursor) {
+    return cursor.dropParentUntil(parent -> parent instanceof J.ClassDeclaration || parent instanceof J.MethodDeclaration)
+        .getValue() instanceof J.ClassDeclaration;
+  }
+
+  @EqualsAndHashCode(callSuper = true)
+  private static class FindInstanceDataAccess extends JavaIsoVisitor<AtomicBoolean> {
+    private final J.Identifier currentMethod;
+    private final Set<J.MethodDeclaration> instanceMethods;
+    private final Set<J.VariableDeclarations.NamedVariable> instanceVariables;
+
+    private FindInstanceDataAccess(J.Identifier currentMethod,
+        Set<J.MethodDeclaration> instanceMethods,
+        Set<J.VariableDeclarations.NamedVariable> instanceVariables
+        ) {
+      this.currentMethod = currentMethod;
+      this.instanceMethods = instanceMethods;
+      this.instanceVariables = instanceVariables;
+    }
+
+    /**
+     * @param method the method to search for.
+     * @return whether has instance data access in this method
+     */
+    static AtomicBoolean find(J.MethodDeclaration method,
+        Set<J.MethodDeclaration> instanceMethods,
+        Set<J.VariableDeclarations.NamedVariable> instanceVariables
+    ) {
+      return new FindInstanceDataAccess(method.getName(), instanceMethods, instanceVariables)
+          .reduce(method, new AtomicBoolean());
+    }
+
+    @Override
+    public J.Identifier visitIdentifier(J.Identifier identifier, AtomicBoolean hasInstanceDataAccess) {
+      System.out.println("[Kun] FindInstanceDataAccess.visitIdentifier : " + identifier);
+      if (hasInstanceDataAccess.get()) {
+        return identifier;
+      }
+
+      J.Identifier id = super.visitIdentifier(identifier, hasInstanceDataAccess);
+
+      // skip the method itself identifier.
+      if (id.getSimpleName().equals(currentMethod.getSimpleName()) && id.getId().equals(currentMethod.getId())) {
+        return id;
+      }
+
+      boolean isInstanceVariable =
+          instanceVariables.stream().anyMatch(v -> v.getSimpleName().equals(id.getSimpleName()));
+
+      boolean isInstanceMethod =
+          instanceMethods.stream().anyMatch(m -> m.getName().getSimpleName().equals(id.getSimpleName()));
+
+      if (isInstanceVariable || isInstanceMethod) {
+        hasInstanceDataAccess.set(true);
+      }
+
+      return id;
+    }
+  }
+
+  @Value
+  @EqualsAndHashCode(callSuper = true)
+  private static class CollectInstanceVariables extends JavaIsoVisitor<Set<J.VariableDeclarations.NamedVariable>> {
+    Set<J.VariableDeclarations.NamedVariable> instanceVariables;
+
+    /**
+     * @param classDecl The target class to collect for
+     * @return a set of instance variables
+     */
+    static Set<J.VariableDeclarations.NamedVariable> collect(J.ClassDeclaration classDecl) {
+      Set<J.VariableDeclarations.NamedVariable> vs = new HashSet<>();
+      return new CollectInstanceVariables(vs)
+          .reduce(classDecl, vs);
+    }
+
+    @Override
+    public J.VariableDeclarations visitVariableDeclarations(J.VariableDeclarations multiVariable,
+        Set<J.VariableDeclarations.NamedVariable> instanceVariables
+    ) {
+      System.out.println("[Kun] CollectInstanceVariables.visitVariableDeclarations : " + multiVariable);
+
+      J.VariableDeclarations mv = super.visitVariableDeclarations(multiVariable, instanceVariables);
+
+      // skip class variables
+      if (mv.hasModifier(J.Modifier.Type.Static)) {
+        return mv;
+      }
+
+      instanceVariables.addAll(multiVariable.getVariables());
+      return mv;
+    }
+
+    @Override
+    public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method,
+        Set<J.VariableDeclarations.NamedVariable> instanceVariables
+    ) {
+      System.out.println("[Kun] CollectInstanceVariables.visitMethodDeclaration : " + method);
+      // skip method sub-tree traversal
+      return method;
+    }
+  }
+
+  @Value
+  @EqualsAndHashCode(callSuper = true)
+  private static class CollectInstanceMethods extends JavaIsoVisitor<Set<J.MethodDeclaration>> {
+    Set<J.MethodDeclaration> instanceMethods;
+
+    /**
+     * @param classDecl The cursor of class declaration
+     * @return a set of instance methods
+     */
+    static Set<J.MethodDeclaration> collect(J.ClassDeclaration classDecl) {
+      Set<J.MethodDeclaration> ms = new HashSet<>();
+      return new CollectInstanceMethods(ms)
+          .reduce(classDecl, ms);
+    }
+
+    @Override
+    public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method,
+        Set<J.MethodDeclaration> instanceMethods
+    ) {
+      System.out.println("[Kun] CollectInstanceMethods.visitMethodDeclaration : " + method);
+
+      // skip class methods
+      if (method.hasModifier(J.Modifier.Type.Static)) {
+        return method;
+      }
+
+      instanceMethods.add(method);
+
+      // skip method sub-tree traversal
+      return method;
+    }
+  }
+}

--- a/src/main/java/com/yourorg/StaticizeNonOverridableMethods.java
+++ b/src/main/java/com/yourorg/StaticizeNonOverridableMethods.java
@@ -23,7 +23,6 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
-import org.openrewrite.Cursor;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
 import org.openrewrite.Tree;
@@ -54,9 +53,6 @@ public class StaticizeNonOverridableMethods extends Recipe {
 
       @Override
       public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
-        // todo, clean up log
-        System.out.println("[Kun] visitClassDeclaration : " + classDecl);
-
         // skip static class
         if (classDecl.hasModifier(J.Modifier.Type.Static)) {
           return classDecl;
@@ -70,9 +66,6 @@ public class StaticizeNonOverridableMethods extends Recipe {
 
       @Override
       public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
-        // todo, clean up log
-        System.out.println("[Kun] visitMethodDeclaration : " + method.toString());
-
         J.MethodDeclaration m = super.visitMethodDeclaration(method, ctx);
 
         // if it already has `static` modifier, it doesn't need to add again.
@@ -142,8 +135,6 @@ public class StaticizeNonOverridableMethods extends Recipe {
 
     @Override
     public J.Identifier visitIdentifier(J.Identifier identifier, AtomicBoolean hasInstanceDataAccess) {
-      // todo, clean up log
-      System.out.println("[Kun] FindInstanceDataAccess.visitIdentifier : " + identifier);
       if (hasInstanceDataAccess.get()) {
         return identifier;
       }
@@ -156,9 +147,12 @@ public class StaticizeNonOverridableMethods extends Recipe {
       if (id.getSimpleName().equals(currentMethod.getSimpleName())
           && id.getId().equals(currentMethod.getId())
           && id.getType() == null
+          && id.getFieldType() == null
       ) {
         return id;
       }
+
+      // todo, kunli, consider J.Identifier.getFieldType()
 
       // Do name matching here, since the loose checking conditions here makes lower false rewrites.
       boolean isInstanceVariable = instanceVariables.stream()
@@ -191,9 +185,6 @@ public class StaticizeNonOverridableMethods extends Recipe {
     public J.VariableDeclarations visitVariableDeclarations(J.VariableDeclarations multiVariable,
         Set<J.VariableDeclarations.NamedVariable> instanceVariables
     ) {
-      // todo, clean up log
-      System.out.println("[Kun] CollectInstanceVariables.visitVariableDeclarations : " + multiVariable);
-
       J.VariableDeclarations mv = super.visitVariableDeclarations(multiVariable, instanceVariables);
 
       // skip class variables
@@ -209,8 +200,6 @@ public class StaticizeNonOverridableMethods extends Recipe {
     public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method,
         Set<J.VariableDeclarations.NamedVariable> instanceVariables
     ) {
-      // todo, clean up log
-      System.out.println("[Kun] CollectInstanceVariables.visitMethodDeclaration : " + method);
       // skip method sub-tree traversal
       return method;
     }
@@ -232,9 +221,6 @@ public class StaticizeNonOverridableMethods extends Recipe {
     public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method,
         Set<J.MethodDeclaration> instanceMethods
     ) {
-      // todo, clean up log
-      System.out.println("[Kun] CollectInstanceMethods.visitMethodDeclaration : " + method);
-
       // skip class methods
       if (method.hasModifier(J.Modifier.Type.Static)) {
         return method;

--- a/src/main/java/com/yourorg/StaticizeNonOverridableMethods.java
+++ b/src/main/java/com/yourorg/StaticizeNonOverridableMethods.java
@@ -38,12 +38,12 @@ public class StaticizeNonOverridableMethods extends Recipe {
 
   @Override
   public String getDisplayName() {
-    return "Add `static` to private or final method that don't access instance data";
+    return "Add `static` modifiers to private or final methods that don't access instance data";
   }
 
   @Override
   public String getDescription() {
-    return "Add the `static` modifier keyword to non-overridable methods (private or final) that don’t access instance data.";
+    return "Add `static` modifiers to non-overridable methods (private or final) that don’t access instance data.";
   }
 
   @Override
@@ -113,11 +113,6 @@ public class StaticizeNonOverridableMethods extends Recipe {
     return m.withModifiers(ModifierOrder.sortModifiers(modifiers));
   }
 
-  private boolean isField(Cursor cursor) {
-    return cursor.dropParentUntil(parent -> parent instanceof J.ClassDeclaration || parent instanceof J.MethodDeclaration)
-        .getValue() instanceof J.ClassDeclaration;
-  }
-
   @EqualsAndHashCode(callSuper = true)
   private static class FindInstanceDataAccess extends JavaIsoVisitor<AtomicBoolean> {
     private final J.Identifier currentMethod;
@@ -166,11 +161,11 @@ public class StaticizeNonOverridableMethods extends Recipe {
       }
 
       // Do name matching here, since the loose checking conditions here makes lower false rewrites.
-      boolean isInstanceVariable =
-          instanceVariables.stream().anyMatch(v -> v.getSimpleName().equals(id.getSimpleName()));
+      boolean isInstanceVariable = instanceVariables.stream()
+          .anyMatch(v -> v.getSimpleName().equals(id.getSimpleName()));
 
-      boolean isInstanceMethod =
-          instanceMethods.stream().anyMatch(m -> m.getName().getSimpleName().equals(id.getSimpleName()));
+      boolean isInstanceMethod = instanceMethods.stream()
+          .anyMatch(m -> m.getName().getSimpleName().equals(id.getSimpleName()));
 
       if (isInstanceVariable || isInstanceMethod) {
         hasInstanceDataAccess.set(true);
@@ -188,9 +183,8 @@ public class StaticizeNonOverridableMethods extends Recipe {
      * @return a set of instance variables
      */
     static Set<J.VariableDeclarations.NamedVariable> collect(J.ClassDeclaration classDecl) {
-      Set<J.VariableDeclarations.NamedVariable> vs = new HashSet<>();
       return new CollectInstanceVariables()
-          .reduce(classDecl, vs);
+          .reduce(classDecl, new HashSet<>());
     }
 
     @Override
@@ -230,9 +224,8 @@ public class StaticizeNonOverridableMethods extends Recipe {
      * @return a set of instance methods
      */
     static Set<J.MethodDeclaration> collect(J.ClassDeclaration classDecl) {
-      Set<J.MethodDeclaration> ms = new HashSet<>();
       return new CollectInstanceMethods()
-          .reduce(classDecl, ms);
+          .reduce(classDecl, new HashSet<>());
     }
 
     @Override
@@ -248,8 +241,6 @@ public class StaticizeNonOverridableMethods extends Recipe {
       }
 
       instanceMethods.add(method);
-
-      // skip method sub-tree traversal
       return method;
     }
   }

--- a/src/main/java/com/yourorg/StaticizeNonOverridableMethods.java
+++ b/src/main/java/com/yourorg/StaticizeNonOverridableMethods.java
@@ -155,11 +155,17 @@ public class StaticizeNonOverridableMethods extends Recipe {
 
       J.Identifier id = super.visitIdentifier(identifier, hasInstanceDataAccess);
 
-      // skip the method itself identifier.
-      if (id.getSimpleName().equals(currentMethod.getSimpleName()) && id.getId().equals(currentMethod.getId())) {
+      // Skip the method itself identifier.
+      // UUID check is necessary to make sure it's the identifier of the method we are checking here.
+      // to cover the scenario that the variable and method having the same name.
+      if (id.getSimpleName().equals(currentMethod.getSimpleName())
+          && id.getId().equals(currentMethod.getId())
+          && id.getType() == null
+      ) {
         return id;
       }
 
+      // Do name matching here, since the loose checking conditions here makes lower false rewrites.
       boolean isInstanceVariable =
           instanceVariables.stream().anyMatch(v -> v.getSimpleName().equals(id.getSimpleName()));
 

--- a/src/main/java/com/yourorg/StaticizeNonOverridableMethods.java
+++ b/src/main/java/com/yourorg/StaticizeNonOverridableMethods.java
@@ -49,12 +49,12 @@ public class StaticizeNonOverridableMethods extends Recipe {
   @Override
   public JavaIsoVisitor<ExecutionContext> getVisitor() {
     return new JavaIsoVisitor<ExecutionContext>() {
-
-      private Set<J.VariableDeclarations.NamedVariable> instanceVariables = new HashSet<>();
-      private Set<J.MethodDeclaration> instanceMethods = new HashSet<>();
+      private final Set<J.VariableDeclarations.NamedVariable> instanceVariables = new HashSet<>();
+      private final Set<J.MethodDeclaration> instanceMethods = new HashSet<>();
 
       @Override
       public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
+        // todo, clean up log
         System.out.println("[Kun] visitClassDeclaration : " + classDecl);
 
         // skip static class
@@ -62,17 +62,15 @@ public class StaticizeNonOverridableMethods extends Recipe {
           return classDecl;
         }
 
-        Set<J.VariableDeclarations.NamedVariable> vs = CollectInstanceVariables.collect(classDecl);
-        instanceVariables.addAll(vs);
-
-        Set<J.MethodDeclaration> ms = CollectInstanceMethods.collect(classDecl);
-        instanceMethods.addAll(ms);
+        instanceVariables.addAll(CollectInstanceVariables.collect(classDecl));
+        instanceMethods.addAll(CollectInstanceMethods.collect(classDecl));
 
         return super.visitClassDeclaration(classDecl, ctx);
       }
 
       @Override
       public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
+        // todo, clean up log
         System.out.println("[Kun] visitMethodDeclaration : " + method.toString());
 
         J.MethodDeclaration m = super.visitMethodDeclaration(method, ctx);
@@ -149,6 +147,7 @@ public class StaticizeNonOverridableMethods extends Recipe {
 
     @Override
     public J.Identifier visitIdentifier(J.Identifier identifier, AtomicBoolean hasInstanceDataAccess) {
+      // todo, clean up log
       System.out.println("[Kun] FindInstanceDataAccess.visitIdentifier : " + identifier);
       if (hasInstanceDataAccess.get()) {
         return identifier;
@@ -178,15 +177,13 @@ public class StaticizeNonOverridableMethods extends Recipe {
   @Value
   @EqualsAndHashCode(callSuper = true)
   private static class CollectInstanceVariables extends JavaIsoVisitor<Set<J.VariableDeclarations.NamedVariable>> {
-    Set<J.VariableDeclarations.NamedVariable> instanceVariables;
-
     /**
      * @param classDecl The target class to collect for
      * @return a set of instance variables
      */
     static Set<J.VariableDeclarations.NamedVariable> collect(J.ClassDeclaration classDecl) {
       Set<J.VariableDeclarations.NamedVariable> vs = new HashSet<>();
-      return new CollectInstanceVariables(vs)
+      return new CollectInstanceVariables()
           .reduce(classDecl, vs);
     }
 
@@ -194,6 +191,7 @@ public class StaticizeNonOverridableMethods extends Recipe {
     public J.VariableDeclarations visitVariableDeclarations(J.VariableDeclarations multiVariable,
         Set<J.VariableDeclarations.NamedVariable> instanceVariables
     ) {
+      // todo, clean up log
       System.out.println("[Kun] CollectInstanceVariables.visitVariableDeclarations : " + multiVariable);
 
       J.VariableDeclarations mv = super.visitVariableDeclarations(multiVariable, instanceVariables);
@@ -211,6 +209,7 @@ public class StaticizeNonOverridableMethods extends Recipe {
     public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method,
         Set<J.VariableDeclarations.NamedVariable> instanceVariables
     ) {
+      // todo, clean up log
       System.out.println("[Kun] CollectInstanceVariables.visitMethodDeclaration : " + method);
       // skip method sub-tree traversal
       return method;
@@ -220,15 +219,13 @@ public class StaticizeNonOverridableMethods extends Recipe {
   @Value
   @EqualsAndHashCode(callSuper = true)
   private static class CollectInstanceMethods extends JavaIsoVisitor<Set<J.MethodDeclaration>> {
-    Set<J.MethodDeclaration> instanceMethods;
-
     /**
      * @param classDecl The cursor of class declaration
      * @return a set of instance methods
      */
     static Set<J.MethodDeclaration> collect(J.ClassDeclaration classDecl) {
       Set<J.MethodDeclaration> ms = new HashSet<>();
-      return new CollectInstanceMethods(ms)
+      return new CollectInstanceMethods()
           .reduce(classDecl, ms);
     }
 
@@ -236,6 +233,7 @@ public class StaticizeNonOverridableMethods extends Recipe {
     public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method,
         Set<J.MethodDeclaration> instanceMethods
     ) {
+      // todo, clean up log
       System.out.println("[Kun] CollectInstanceMethods.visitMethodDeclaration : " + method);
 
       // skip class methods

--- a/src/test/java/com/yourorg/StaticizeNonOverridableMethodsTest.java
+++ b/src/test/java/com/yourorg/StaticizeNonOverridableMethodsTest.java
@@ -1,0 +1,433 @@
+package com.yourorg;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.*;
+
+
+public class StaticizeNonOverridableMethodsTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new StaticizeNonOverridableMethods());
+    }
+
+    // todo, test purpose only, to be removed
+    @Test
+    void kunTestPurposeOnly() {
+        rewriteRun(
+            java("""
+                        class A {
+                          private int a;
+                          private int b;
+                          private static int z;
+                          
+                          private int func1() {
+                            return a;
+                          }
+                        
+                          private int func2(int x) {
+                            int c = 2;
+                            return c * x;
+                          }
+                        
+                          private int func3(int x) {
+                            int c = 2;
+                            int d = 0;
+                            for (int i = 0; i < c ;i++) {
+                              int a = 1;
+                              if (d > 0) {
+                                d += a;
+                              }
+                              d += c;
+                            }
+                            return c * x + a;
+                          }
+                          
+                          private int func4() {
+                             return z + 1;
+                          }
+                        }
+                    """,
+                """
+                        class A {
+                          private int a;
+                          private int b;
+                          private static int z;
+                          
+                          private int func1() {
+                            return a;
+                          }
+                        
+                          private static int func2(int x) {
+                            int c = 2;
+                            return c * x;
+                          }
+                        
+                          private int func3(int x) {
+                            int c = 2;
+                            int d = 0;
+                            for (int i = 0; i < c ;i++) {
+                              int a = 1;
+                              if (d > 0) {
+                                d += a;
+                              }
+                              d += c;
+                            }
+                            return c * x + a;
+                          }
+                          
+                          private static int func4() {
+                             return z + 1;
+                          }
+                        }
+                    """
+            )
+        );
+    }
+
+    @Test
+    void instanceVariableAccessed() {
+        rewriteRun(
+            java("""
+                        class A {
+                          private int a;
+                        
+                          private int func1() {
+                            return a;
+                          }
+                          
+                          final int func2() {
+                            return a * 2;
+                          }
+                          
+                          private final int func3() {
+                            return a * 3;
+                          }
+                        }
+                    """
+            )
+        );
+    }
+
+    @Test
+    void instanceVariableNotAccessed() {
+        rewriteRun(
+            java("""
+                        class A {
+                          private int a;
+                          
+                          private int func1(int b) {
+                            int c = 2;
+                            return c + b;
+                          }
+                          
+                          final int func2(int b) {
+                            int c = 2;
+                            return c - b;
+                          }
+                          
+                          private final int func3(int b) {
+                            int c = 2;
+                            return c * b;
+                          }
+                        }
+                    """,
+                """
+                        class A {
+                          private int a;
+                          
+                          private static int func1(int b) {
+                            int c = 2;
+                            return c + b;
+                          }
+                          
+                          static final int func2(int b) {
+                            int c = 2;
+                            return c - b;
+                          }
+                          
+                          private static final int func3(int b) {
+                            int c = 2;
+                            return c * b;
+                          }
+                        }
+                    """
+            )
+        );
+    }
+
+    @Test
+    void overridableMethodsIgnored() {
+        rewriteRun(
+            java("""
+                        class A {
+                          public int func1(int a, int b) {
+                            return a + b;
+                          }
+                        
+                          protected int func2(int a, int b) {
+                            return a - b;
+                          }
+                        
+                          int func3(int a, int b) {
+                            return a * b;
+                          }
+                        }
+                    """
+            )
+        );
+    }
+
+    @Test
+    void instanceMethodAccessed() {
+        rewriteRun(
+            java("""
+                        class A {
+                          int a = 1;
+                        
+                          private int fun1() {
+                            return a;
+                          }
+                          
+                          private int fun2(int b) {
+                            return fun1() + b;
+                          }
+                          
+                          final int func3(int b) {
+                            return fun1() - b;
+                          }
+                          
+                          private final int func4(int b) {
+                            return fun1() * b;
+                          }
+                        }
+                    """
+            )
+        );
+    }
+
+    @Test
+    void classVariableAccessed() {
+        rewriteRun(
+            java("""
+                        class A {
+                          private static int a = 1;
+                        
+                          private int func1() {
+                            return a;
+                          }
+                          
+                          final int func2() {
+                            return a + 1;
+                          }
+                          
+                          private final int func3() {
+                            return a + 2;
+                          }
+                        }
+                    """,
+                """
+                        class A {
+                          private static int a = 1;
+                        
+                          private static int func1() {
+                            return a;
+                          }
+                          
+                          static final int func2() {
+                            return a + 1;
+                          }
+                          
+                          private static final int func3() {
+                            return a + 2;
+                          }
+                        }
+                    """
+            )
+        );
+    }
+
+    @Test
+    void classMethodAccessed() {
+        rewriteRun(
+            java("""
+                        class A {
+                          private static int a = 1;
+                        
+                          private static int func1() {
+                            return a;
+                          }
+                        
+                          private int func2(int b) {
+                            return func1() + b;
+                          }
+                        }
+                    """,
+                """
+                        class A {
+                          private static int a = 1;
+                                            
+                          private static int func1() {
+                            return a;
+                          }
+                        
+                          private static int func2(int b) {
+                            return func1() + b;
+                          }
+                        }
+                    """
+            )
+        );
+    }
+
+    @Test
+    void sameNameInstanceVariableInScope() {
+        rewriteRun(
+            java("""
+                        class A {
+                          int a = 1;
+                        
+                          private int func(int b) {
+                            int c = 2;
+                            for (int i = 0; i < b ;i++) {
+                              int a = 2;
+                              c += a;
+                            }
+                            return c + a;
+                          }
+                        }
+                    """
+            )
+        );
+    }
+
+    @Disabled("The same name local variable could make compile errors without a scope check.")
+    @Test
+    void sameNameInstanceVariable() {
+        rewriteRun(
+            java("""
+                        class A {
+                          int a = 1;
+                        
+                          private int func(int b) {
+                            int a = 2;
+                            return a + b;
+                          }
+                        }
+                    """,
+                """
+                        class A {
+                          int a = 1;
+                        
+                          private static int func(int b) {
+                            int a = 2;
+                            return a + b;
+                          }
+                        }
+                    """
+            )
+        );
+    }
+
+    // todo, revisit to check if it's necessary
+    @Test
+    void sameNameClassVariableInScope() {
+        rewriteRun(
+            java("""
+                        class A {
+                          static int a = 1;
+                        
+                          private int func(int b) {
+                            int c = 2;
+                            for (int i = 0; i < b ;i++) {
+                              int a = 2;
+                              c += a;
+                            }
+                            return c + a;
+                          }
+                        }
+                    """,
+                """
+                        class A {
+                          static int a = 1;
+                        
+                          private static int func(int b) {
+                            int c = 2;
+                            for (int i = 0; i < b ;i++) {
+                              int a = 2;
+                              c += a;
+                            }
+                            return c + a;
+                          }
+                        }
+                    """
+            )
+        );
+    }
+
+    @Disabled("todo")
+    @Test
+    void nestedClassMethods() {
+        rewriteRun(
+            java("""
+                        class A {
+                          private static int a = 1;
+                          private static int b = 2;
+                        
+                          private int func1() {
+                            return a * 2;
+                          }
+                        
+                          private int func2() {
+                            int x = func1();
+                            return x + b;
+                          }
+                        }
+                    """,
+                """
+                        class A {
+                          private static int a = 1;
+                          private static int b = 2;
+                        
+                          private static int func1() {
+                            return a * 2;
+                          }
+                        
+                          private static int func2() {
+                            int x = func1();
+                            return x + b;
+                          }
+                        }
+                    """
+            )
+        );
+    }
+
+    @Test
+    void staticClassIgnored() {
+        rewriteRun(
+            java("""
+                        class A {
+                          int a = 1;
+                        
+                          private int func1() {
+                            B b = new B();
+                            return a + 1;
+                          }
+                        
+                          private static class B {
+                            int b = 0;
+                            int func2(int x) {
+                              return x + 1;
+                            }
+                          }
+                        }
+                    """
+            )
+        );
+    }
+}

--- a/src/test/java/com/yourorg/StaticizeNonOverridableMethodsTest.java
+++ b/src/test/java/com/yourorg/StaticizeNonOverridableMethodsTest.java
@@ -430,4 +430,20 @@ public class StaticizeNonOverridableMethodsTest implements RewriteTest {
             )
         );
     }
+
+    @Test
+    void methodNameIsSameWithInstanceVariable() {
+        rewriteRun(
+            java("""
+                    class A {
+                      int count = 1;
+                    
+                      private int count(int x) {
+                        return count + x;
+                      }
+                    }
+                    """
+            )
+        );
+    }
 }

--- a/src/test/java/com/yourorg/StaticizeNonOverridableMethodsTest.java
+++ b/src/test/java/com/yourorg/StaticizeNonOverridableMethodsTest.java
@@ -293,6 +293,7 @@ public class StaticizeNonOverridableMethodsTest implements RewriteTest {
         );
     }
 
+    // todo, kunli, for this case, current recipe staticize `func1` only. going to support this case,
     @Disabled
     @Test
     void nestedClassMethods() {

--- a/src/test/java/com/yourorg/StaticizeNonOverridableMethodsTest.java
+++ b/src/test/java/com/yourorg/StaticizeNonOverridableMethodsTest.java
@@ -7,86 +7,11 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.*;
 
-
 public class StaticizeNonOverridableMethodsTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipe(new StaticizeNonOverridableMethods());
-    }
-
-    // todo, test purpose only, to be removed
-    @Test
-    void kunTestPurposeOnly() {
-        rewriteRun(
-            java("""
-                        class A {
-                          private int a;
-                          private int b;
-                          private static int z;
-                          
-                          private int func1() {
-                            return a;
-                          }
-                        
-                          private int func2(int x) {
-                            int c = 2;
-                            return c * x;
-                          }
-                        
-                          private int func3(int x) {
-                            int c = 2;
-                            int d = 0;
-                            for (int i = 0; i < c ;i++) {
-                              int a = 1;
-                              if (d > 0) {
-                                d += a;
-                              }
-                              d += c;
-                            }
-                            return c * x + a;
-                          }
-                          
-                          private int func4() {
-                             return z + 1;
-                          }
-                        }
-                    """,
-                """
-                        class A {
-                          private int a;
-                          private int b;
-                          private static int z;
-                          
-                          private int func1() {
-                            return a;
-                          }
-                        
-                          private static int func2(int x) {
-                            int c = 2;
-                            return c * x;
-                          }
-                        
-                          private int func3(int x) {
-                            int c = 2;
-                            int d = 0;
-                            for (int i = 0; i < c ;i++) {
-                              int a = 1;
-                              if (d > 0) {
-                                d += a;
-                              }
-                              d += c;
-                            }
-                            return c * x + a;
-                          }
-                          
-                          private static int func4() {
-                             return z + 1;
-                          }
-                        }
-                    """
-            )
-        );
     }
 
     @Test
@@ -297,7 +222,7 @@ public class StaticizeNonOverridableMethodsTest implements RewriteTest {
                               int a = 2;
                               c += a;
                             }
-                            return c + a;
+                            return c + 1;
                           }
                         }
                     """
@@ -305,7 +230,7 @@ public class StaticizeNonOverridableMethodsTest implements RewriteTest {
         );
     }
 
-    @Disabled("The same name local variable could make compile errors without a scope check.")
+    @Disabled("The same name local variable could make compile errors if without a scope check.")
     @Test
     void sameNameInstanceVariable() {
         rewriteRun(
@@ -333,7 +258,6 @@ public class StaticizeNonOverridableMethodsTest implements RewriteTest {
         );
     }
 
-    // todo, revisit to check if it's necessary
     @Test
     void sameNameClassVariableInScope() {
         rewriteRun(
@@ -369,7 +293,7 @@ public class StaticizeNonOverridableMethodsTest implements RewriteTest {
         );
     }
 
-    @Disabled("todo")
+    @Disabled
     @Test
     void nestedClassMethods() {
         rewriteRun(


### PR DESCRIPTION
### This PR implements the following
add staticize method recipe to add `static` modifiers to non-overridable methods (private or final) that don’t access instance data.
